### PR TITLE
add highline gem to Gemfile

### DIFF
--- a/serverspec/Gemfile
+++ b/serverspec/Gemfile
@@ -13,3 +13,4 @@ gem "rspec-retry"
 gem "docker-compose-api", :git => 'https://github.com/nanliu/docker-compose-api.git', :branch => 'env'
 gem "serverspec", "~> 2.38.0"
 gem "dockerspec", "~> 0.4.1"
+gem "highline", "~> 1.7"


### PR DESCRIPTION
Hi nanliu,

I just added _highline_ gem to Gemfile because _spec_helper.rb_ needs it for console input and output with low-level methods.

Thank you for your work !

Joel